### PR TITLE
Suppressed the PSSA rule PSAvoidUsingComputerNameHardcoded to unblock…

### DIFF
--- a/Examples/ExampleConfiguration-RemoteDesktopAdmin.ps1
+++ b/Examples/ExampleConfiguration-RemoteDesktopAdmin.ps1
@@ -1,3 +1,6 @@
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingComputerNameHardcoded', '')] 
+param()
+
 Configuration AllowRemoteDesktopAdminConnections
 {
     Import-DscResource -Module xRemoteDesktopAdmin, xNetworking

--- a/Examples/ExampleConfiguration-RemoteDesktopAdminWithEncryptedPassword.ps1
+++ b/Examples/ExampleConfiguration-RemoteDesktopAdminWithEncryptedPassword.ps1
@@ -1,3 +1,5 @@
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingComputerNameHardcoded', '')] 
+param()
 # The configuration data section specifies which certificate and thumbprint to use for encrypting the password
 $ConfigData = @{
     AllNodes = @(

--- a/Examples/ExampleConfiguration-RemoteDesktopAdminWithUnEncryptedPassword.ps1
+++ b/Examples/ExampleConfiguration-RemoteDesktopAdminWithUnEncryptedPassword.ps1
@@ -1,3 +1,5 @@
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingComputerNameHardcoded', '')] 
+param()
 # The configuration data section specifies to allow using a plain text stored password
 $ConfigData = @{
     AllNodes = @(

--- a/Examples/ExampleConfiguration-RemoteDesktopAdminWithUnEncryptedPassword.ps1
+++ b/Examples/ExampleConfiguration-RemoteDesktopAdminWithUnEncryptedPassword.ps1
@@ -1,4 +1,5 @@
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingComputerNameHardcoded', '')] 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')] 
 param()
 # The configuration data section specifies to allow using a plain text stored password
 $ConfigData = @{


### PR DESCRIPTION
… tests in AppVeyor. It is okay to suppress this rule in the Examples
#14

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xremotedesktopadmin/15)

<!-- Reviewable:end -->
